### PR TITLE
- Replace "Learndash" with "LearnDash" throughout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Effective Learndash
+# Effective LearnDash
 
-Create Wordpress users and read Learndash course progress. This is an unoffocial integration that is not supported or affiliated with WordPress or Learndash.
+Create Wordpress users and read LearnDash course progress. This is an unofficial integration that is not supported or affiliated with WordPress or LearnDash.
 
 ## Getting Started
 
@@ -91,29 +91,29 @@ if user.admin?
 end
 ```
 
-## Configuring Learndash
+## Configuring LearnDash
 
-Your Wordpress should be configured ahead of time with the Learndash plugin.
+Your WordPress should be configured ahead of time with the LearnDash plugin.
 
 Please generate an application password via:
 
 https://make.wordpress.org/core/2020/11/05/application-passwords-integration-guide/
 
-and fill in the username/password details in config/initializers/effective_leardash.rb
+and fill in the username/password details in config/initializers/effective_learndash.rb
 
-## Working with Learndash
+## Working with LearnDash
 
 Visit `/admin/learndash_courses` and Refresh the list of Courses.
 
-Create a New Learndash User will create a new Wordpress/Learndash account with a username/password according to the settings in the config file.
+Create a New LearnDash User will create a new WordPress/LearnDash account with a username/password according to the settings in the config file.
 
 When you create a user, you only get access to the password once. So any existing users will have an unknown password.
 
-Create a new Learndash Enrollment to enroll a learndash user into a course. This will begin tracking their progress.
+Create a new LearnDash Enrollment to enroll a LearnDash user into a course. This will begin tracking their progress.
 
-There are no webhooks or callbacks from Learndash, everything is a GET request that updates the local database.
+There are no webhooks or callbacks from LearnDash, everything is a GET request that updates the local database.
 
-You can refresh an entire learndash user in one operation and it will sync the entire user at once, `user.learndash_user.refresh!`
+You can refresh an entire LearnDash user in one operation and it will sync the entire user at once, `user.learndash_user.refresh!`
 
 ## License
 

--- a/app/controllers/admin/learndash_courses_controller.rb
+++ b/app/controllers/admin/learndash_courses_controller.rb
@@ -7,7 +7,7 @@ module Admin
 
     def refresh
       resource_scope.refresh!
-      flash[:success] = "Successfully refreshed Courses from Learndash"
+      flash[:success] = "Successfully refreshed Courses from LearnDash"
       redirect_to effective_learndash.admin_learndash_courses_path
     end
 

--- a/app/datatables/admin/effective_learndash_courses_datatable.rb
+++ b/app/datatables/admin/effective_learndash_courses_datatable.rb
@@ -4,7 +4,7 @@ module Admin
       order :title
 
       col :id, visible: false
-      col :course_id, label: 'Learndash Id', visible: false
+      col :course_id, label: 'LearnDash Id', visible: false
 
       col :title
       col :status

--- a/app/datatables/admin/effective_learndash_users_datatable.rb
+++ b/app/datatables/admin/effective_learndash_users_datatable.rb
@@ -2,7 +2,7 @@ module Admin
   class EffectiveLearndashUsersDatatable < Effective::Datatable
     datatable do
       col :id, visible: false
-      col :user_id, label: 'Learndash Id', visible: false
+      col :user_id, label: 'LearnDash Id', visible: false
 
       col :last_refreshed, visible: true do |user|
         time_ago_in_words(user.last_synced_at) + ' ago'

--- a/app/datatables/effective_course_registrations_datatable.rb
+++ b/app/datatables/effective_course_registrations_datatable.rb
@@ -6,12 +6,12 @@ class EffectiveCourseRegistrationsDatatable < Effective::Datatable
     col :token, visible: false
     col :created_at, visible: false
 
-    col(:submitted_at, label: 'Registered on') do |registration|
-      registration.submitted_at&.strftime('%F') || 'Incomplete'
+    col :learndash_course, label: 'Title', search: :string do |registration|
+      registration.learndash_course.to_s
     end
 
-    col :learndash_course, search: :string do |registration|
-      registration.learndash_course.to_s
+    col(:submitted_at, label: 'Registered on') do |registration|
+      registration.submitted_at&.strftime('%F') || 'Incomplete'
     end
 
     col :owner, visible: false, search: :string

--- a/app/datatables/effective_learndash_courses_datatable.rb
+++ b/app/datatables/effective_learndash_courses_datatable.rb
@@ -10,12 +10,14 @@ class EffectiveLearndashCoursesDatatable < Effective::Datatable
     order :title
     col :id, visible: false
 
-    col :title, label: 'Title' do |learndash_course|
-      link_to(learndash_course.to_s, effective_learndash.learndash_course_path(learndash_course))
+    col :title do |learndash_course|
+      learndash_course.to_s
     end
 
     actions_col show: false do |learndash_course|
-      if learndash_course.can_register?
+      if current_user.learndash_enrollment(course: learndash_course).present?
+        'Registered. Please access from the home dashboard or applicant wizard.'
+      elsif learndash_course.can_register?
         dropdown_link_to('Register', effective_learndash.new_learndash_course_course_registration_path(learndash_course))
       end
     end

--- a/app/datatables/effective_learndash_enrollments_datatable.rb
+++ b/app/datatables/effective_learndash_enrollments_datatable.rb
@@ -1,11 +1,11 @@
 # Dashboard LearndashUsers
 class EffectiveLearndashEnrollmentsDatatable < Effective::Datatable
   datatable do
-    col :learndash_course do |enrollment|
-      link_to(enrollment.learndash_course, EffectiveLearndash.learndash_url, target: '_blank')
+    col :learndash_course, label: 'Title' do |enrollment|
+      enrollment.learndash_course.to_s
     end
 
-    col :progress_status
+    col :progress_status, label: 'Status'
 
     col :last_step, visible: false
     col :steps_completed, visible: false
@@ -16,9 +16,9 @@ class EffectiveLearndashEnrollmentsDatatable < Effective::Datatable
 
     actions_col(show: false) do |enrollment|
       if enrollment.not_started?
-        dropdown_link_to('Start', EffectiveLearndash.learndash_url, target: '_blank')
+        dropdown_link_to('Access Course', EffectiveLearndash.learndash_url, target: '_blank')
       elsif enrollment.in_progress?
-        dropdown_link_to('Continue', EffectiveLearndash.learndash_url, target: '_blank')
+        dropdown_link_to('Continue Course', EffectiveLearndash.learndash_url, target: '_blank')
       else
         dropdown_link_to('Show', EffectiveLearndash.learndash_url, target: '_blank')
       end

--- a/app/models/effective/learndash_api.rb
+++ b/app/models/effective/learndash_api.rb
@@ -146,7 +146,7 @@ module Effective
     end
 
     def username_for(resource)
-      raise('expected a learndash owner') unless resource.class.respond_to?(:effective_learndash_owner?) # This is a user
+      raise('expected a LearnDash owner') unless resource.class.respond_to?(:effective_learndash_owner?) # This is a user
 
       name = EffectiveLearndash.wp_username_for(resource)
       name = "test#{name}" unless Rails.env.production?
@@ -154,7 +154,7 @@ module Effective
     end
 
     def email_for(resource)
-      raise('expected a learndash owner') unless resource.class.respond_to?(:effective_learndash_owner?) # This is a user
+      raise('expected a LearnDash owner') unless resource.class.respond_to?(:effective_learndash_owner?) # This is a user
 
       email = resource.email
       email = "test#{email}" unless Rails.env.production?
@@ -162,7 +162,7 @@ module Effective
     end
 
     def password_for(resource)
-      raise('expected a learndash owner') unless resource.class.respond_to?(:effective_learndash_owner?) # This is a user
+      raise('expected a LearnDash owner') unless resource.class.respond_to?(:effective_learndash_owner?) # This is a user
       EffectiveLearndash.wp_password_for(resource)
     end
 
@@ -178,7 +178,7 @@ module Effective
       elsif response.kind_of?(Array)
         response.first
       else
-        raise("unexpected Learndash API response #{response}")
+        raise("unexpected LearnDash API response #{response}")
       end
     end
 
@@ -199,7 +199,7 @@ module Effective
         elsif response.kind_of?(Array)
           response
         else
-          raise("unexpected Learndash API find_by response #{response}")
+          raise("unexpected LearnDash API find_by response #{response}")
         end
       )
 

--- a/app/views/admin/learndash_courses/_form.html.haml
+++ b/app/views/admin/learndash_courses/_form.html.haml
@@ -6,7 +6,7 @@
     = tab 'Enrollments' do
       %h2 Enrollments
       %p Click the New button from the below table to enroll a user into this course.
-      %p Enrolling a user here will enroll them on the Learndash site.
+      %p Enrolling a user here will enroll them on the LearnDash site.
       %p Alternately, if this course is available for registration, the enrollment will be created upon registration purchase.
 
       - datatable = Admin::EffectiveLearndashEnrollmentsDatatable.new(learndash_course: learndash_course)

--- a/app/views/admin/learndash_courses/_learndash_course.html.haml
+++ b/app/views/admin/learndash_courses/_learndash_course.html.haml
@@ -1,10 +1,10 @@
-= card('Learndash Course') do
+= card('LearnDash Course') do
   %p= learndash_course.title
   %p= link_to(learndash_course.link, learndash_course.link, target: '_blank')
 
-  %p= link_to "Learndash LMS Course Admin", EffectiveLearndash.learndash_url.chomp('/') + "/wp-admin/post.php?post=#{learndash_course.course_id}}&action=edit", target: '_blank'
+  %p= link_to "LearnDash LMS Course Admin", EffectiveLearndash.learndash_url.chomp('/') + "/wp-admin/post.php?post=#{learndash_course.course_id}}&action=edit", target: '_blank'
 
-%h3 Learndash User Enrollments
+%h3 LearnDash User Enrollments
 
 %p Click the New button from the below table to enroll a user into this course.
 

--- a/app/views/admin/learndash_owners/_form.html.haml
+++ b/app/views/admin/learndash_owners/_form.html.haml
@@ -1,5 +1,5 @@
 - if owner.learndash_user.blank?
-  %p #{owner} does not yet have an account on Learndash.
+  %p #{owner} does not yet have an account on LearnDash.
 
 - if owner.learndash_user.present?
   = render('admin/learndash_users/learndash_user', learndash_user: owner.learndash_user)

--- a/app/views/admin/learndash_users/_form.html.haml
+++ b/app/views/admin/learndash_users/_form.html.haml
@@ -1,6 +1,6 @@
 = effective_form_with(model: [:admin, learndash_user], engine: true) do |f|
 
   = f.select :owner, {'Owners' => current_user.class.sorted }, polymorphic: true,
-    hint: 'Create a Learndash user account for this website user'
+    hint: 'Create a LearnDash account for this user'
 
   = f.submit

--- a/app/views/admin/learndash_users/_learndash_user.html.haml
+++ b/app/views/admin/learndash_users/_learndash_user.html.haml
@@ -1,19 +1,19 @@
-= card('Learndash User') do
+= card('LearnDash') do
   %p
     = link_to(learndash_user.owner, "/admin/users/#{learndash_user.owner.to_param}/edit")
-    has an existing account on Learndash.
+    has an existing account on LearnDash.
 
   %ul
     %li Email: #{learndash_user.email}
     %li Username: #{learndash_user.username}
     %li Password: #{learndash_user.password}
 
-  %p= link_to "Learndash LMS User Admin", EffectiveLearndash.learndash_url.chomp('/') + "/wp-admin/user-edit.php?user_id=#{learndash_user.user_id}", target: '_blank'
+  %p= link_to "LearnDash LMS User Admin", EffectiveLearndash.learndash_url.chomp('/') + "/wp-admin/user-edit.php?user_id=#{learndash_user.user_id}", target: '_blank'
 
   %p
     %small Last refreshed #{time_ago_in_words(learndash_user.last_synced_at)} ago.
 
-%h3 Learndash Course Enrollments
+%h3 LearnDash Course Enrollments
 
 %p Click the New button from the below table to manually enroll this user into a new course.
 

--- a/app/views/effective/course_registrations/_summary.html.haml
+++ b/app/views/effective/course_registrations/_summary.html.haml
@@ -2,19 +2,23 @@
   %table.table.table-sm
     %tbody
       %tr
-        %th.border-0 Learndash Course
+        %th.border-0 Course
         %td.border-0
-          %p= link_to(course_registration.course, EffectiveLearndash.learndash_url, target: '_blank')
+          %p
+            %strong=course_registration.course
 
-          %p Please sign into Learndash with the following credentials:
           - learndash_user = course_registration.learndash_owner.learndash_user
+          %p Your course account credentials are:
 
           %ul
-            %li Email: #{learndash_user.email}
-            %li Username: #{learndash_user.username}
-            %li Password: #{learndash_user.password}
+            %li
+              %strong Username:
+              #{learndash_user.username}
+            %li
+              %strong Password:
+              #{learndash_user.password}
 
-          %p= link_to('Learndash LMS', EffectiveLearndash.learndash_url, target: '_blank')
+          %p= link_to('Sign in to your course account', EffectiveLearndash.learndash_url, target: '_blank', class: 'btn btn-primary mb-2')
 
       - if request.path.start_with?('/admin')
         %tr

--- a/app/views/effective/course_registrations/course.html.haml
+++ b/app/views/effective/course_registrations/course.html.haml
@@ -4,8 +4,6 @@
   = card('Course') do
     = render('effective/learndash_courses/learndash_course', learndash_course: resource.learndash_course)
 
-    %p You qualify for #{resource.member_pricing? ? 'member' : 'regular'} pricing.
-
     = effective_form_with(model: resource, url: wizard_path(step), method: :put) do |f|
       = f.hidden_field :id
 

--- a/app/views/effective/course_registrations/submitted.html.haml
+++ b/app/views/effective/course_registrations/submitted.html.haml
@@ -10,7 +10,6 @@
   = link_to "Return to Dashboard", root_path, class: 'btn btn-lg btn-primary mb-4'
 
   = render 'effective/course_registrations/summary', course_registration: resource
-  = render 'effective/course_registrations/course_registration', course_registration: resource
   = render 'effective/course_registrations/orders', course_registration: resource
 
   = link_to "Return to Dashboard", root_path, class: 'btn btn-lg btn-primary'

--- a/app/views/effective/learndash/_dashboard.html.haml
+++ b/app/views/effective/learndash/_dashboard.html.haml
@@ -1,31 +1,32 @@
 - learndash_user = current_user.try(:learndash_user)
 - authorized = learndash_user && EffectiveResources.authorized?(self, :show, learndash_user)
 
-%h2 Learndash Courses
+%h2 Courses
 
 - if learndash_user.blank?
-  %p You do not have a Learndash account.
-
-- if learndash_user.present?
-  %p
-    = succeed('.') do
-      You have an existing account on
-      = link_to('Learndash', EffectiveLearndash.learndash_url, target: '_blank')
+  %p You do not have an account to access courses. When you are enrolled in a course, your account credentials will be displayed here.
 
 - if learndash_user.present? && authorized
   - learndash_user.refresh!
 
-  %p Please sign into Learndash with the following credentials:
+
+  %p Your course account credentials are:
 
   %ul
-    %li Email: #{learndash_user.email}
-    %li Username: #{learndash_user.username}
-    %li Password: #{learndash_user.password}
+    %li
+      %strong Username:
+      #{learndash_user.username}
+    %li
+      %strong Password:
+      #{learndash_user.password}
+
+  %p
+    = link_to('Sign in to your course account', EffectiveLearndash.learndash_url, target: '_blank', class: 'btn btn-primary')
 
   - if learndash_user.learndash_enrollments.present?
-    %p You are enrolled in #{pluralize(learndash_user.learndash_enrollments.length, 'course')}.
-
     - datatable = EffectiveResources.best('EffectiveLearndashEnrollmentsDatatable').new(self)
     = render_datatable(datatable, simple: true)
+
   - else
-    You are not enrolled in any Learndash courses.
+    You are not enrolled in any courses.
+

--- a/app/views/effective/learndash_courses/_learndash_course.html.haml
+++ b/app/views/effective/learndash_courses/_learndash_course.html.haml
@@ -4,7 +4,7 @@
       %th Regular Price
       %td= price_to_currency(learndash_course.regular_price)
     %tr
-      %th Member Price
+      %th Discounted Price
       %td= price_to_currency(learndash_course.member_price)
 
     - if learndash_course.body.present?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ end
 EffectiveLearndash::Engine.routes.draw do
   # Public routes
   scope module: 'effective' do
-    resources :learndash_courses, only: [:index, :show] do
+    resources :learndash_courses, only: [:index] do
       resources :course_registrations, only: [:new, :show, :destroy] do
         resources :build, controller: :course_registrations, only: [:show, :update]
       end

--- a/effective_learndash.gemspec
+++ b/effective_learndash.gemspec
@@ -10,8 +10,8 @@ Gem::Specification.new do |spec|
   spec.authors     = ['Code and Effect']
   spec.email       = ['info@codeandeffect.com']
   spec.homepage    = 'https://github.com/code-and-effect/effective_learndash'
-  spec.summary     = 'Create Wordpress users and read Learndash course progress'
-  spec.description = 'Create Wordpress users and read Learndash course progress'
+  spec.summary     = 'Create Wordpress users and read LearnDash course progress'
+  spec.description = 'Create Wordpress users and read LearnDash course progress'
   spec.license     = 'MIT'
 
   spec.files = Dir["{app,config,db,lib}/**/*"] + ['MIT-LICENSE', 'Rakefile', 'README.md']


### PR DESCRIPTION
- Try to avoid using the word "LearnDash" for front-end users
- Only make the access course available as a big button on the dashboard and order receipt, instead of making course titles link
- Don't show course registration partial on order submitted step
- Don't have a LearndashCourse#show route