### PR TITLE
Use shared pagination normalization

### DIFF
--- a/app/models/effective/learndash_course.rb
+++ b/app/models/effective/learndash_course.rb
@@ -56,7 +56,7 @@ module Effective
     scope :published, -> { all }
 
     scope :paginate, -> (page: nil, per_page: nil) {
-      page = EffectiveResources.normalize_page(page)
+      page = EffectiveResources.normalize_page(page) || 1
       offset = [(page - 1), 0].max * (per_page || EffectiveLearndash.per_page)
 
       limit(per_page).offset(offset)

--- a/app/models/effective/learndash_course.rb
+++ b/app/models/effective/learndash_course.rb
@@ -56,7 +56,7 @@ module Effective
     scope :published, -> { all }
 
     scope :paginate, -> (page: nil, per_page: nil) {
-      page = (page || 1).to_i
+      page = EffectiveResources.normalize_page(page)
       offset = [(page - 1), 0].max * (per_page || EffectiveLearndash.per_page)
 
       limit(per_page).offset(offset)


### PR DESCRIPTION
## Summary
- normalize LearndashCourse.paginate page values through EffectiveResources
- reject malformed and noncanonical page parameters through the shared parser
- keep upper-bound validation outside the pagination scope

## Dependency
- Requires https://github.com/code-and-effect/effective_resources/pull/60

## Tests
- mise exec ruby@3.1.2 -- bundle exec ruby -S rails test test/models/learndash_test.rb
- 1 run, 2 assertions, 0 failures

Duplicate parser contract tests were removed from this downstream gem because that behavior is covered by effective_resources.